### PR TITLE
📝 Docs: Add Expo usage information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ cd ios && pod install
 
 <br>
 
+### Expo
+
+- ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+- ❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+
 ### Troubleshooting
 
 If you encounter any errors/bugs while using this library, or want a particular feature implemented, please create an issue! ✨


### PR DESCRIPTION
This adds the standard message to document Expo compatibility as covered in [this doc](https://www.notion.so/expo/Documenting-Expo-support-in-READMEs-f250a20b4bd5472cab0757918cb21062#ae1f2e4734b34fe3be292f777591517b).

For example: https://github.com/mrousavy/react-native-blurhash#expo

Fixes #36