### PR TITLE
fix: build for macOS catalyst

### DIFF
--- a/ios/src/Extensions+Init/UIMenu+Init.swift
+++ b/ios/src/Extensions+Init/UIMenu+Init.swift
@@ -19,6 +19,7 @@ extension UIMenu.Options {
   };
 };
 
+#if !targetEnvironment(macCatalyst)
 #if swift(>=5.7)
 @available(iOS 16, *)
 extension UIMenu.ElementSize {
@@ -33,4 +34,4 @@ extension UIMenu.ElementSize {
   };
 };
 #endif
-
+#endif

--- a/ios/src/Extensions+Init/UIMenuElement+Init.swift
+++ b/ios/src/Extensions+Init/UIMenuElement+Init.swift
@@ -15,10 +15,12 @@ extension UIMenuElement.Attributes {
       case "disabled"   : self = .disabled;
       case "destructive": self = .destructive;
       
+      #if !targetEnvironment(macCatalyst)
       #if swift(>=5.7)
       case "keepsMenuPresented":
         guard #available(iOS 16.0, *) else { return nil };
         self = .keepsMenuPresented
+      #endif
       #endif
       
       default: return nil;

--- a/ios/src/ReactNative/RNIContextMenu/RNIMenuItem.swift
+++ b/ios/src/ReactNative/RNIContextMenu/RNIMenuItem.swift
@@ -119,6 +119,7 @@ extension RNIMenuItem {
     );
   };
   
+  #if !targetEnvironment(macCatalyst)
   #if swift(>=5.7)
   @available(iOS 16.0, *)
   var synthesizedPreferredMenuElementSize: UIMenu.ElementSize? {
@@ -127,6 +128,7 @@ extension RNIMenuItem {
     
     return UIMenu.ElementSize(string: menuPreferredElementSize);
   };
+  #endif
   #endif
 };
 
@@ -163,12 +165,14 @@ extension RNIMenuItem {
     };
     #endif
     
+    #if !targetEnvironment(macCatalyst)
     #if swift(>=5.7)
     if #available(iOS 16.0, *),
        let preferredElementSize = self.synthesizedPreferredMenuElementSize {
       
       menu.preferredElementSize = preferredElementSize;
     };
+    #endif
     #endif
     
     return menu;


### PR DESCRIPTION
There are some iOS 16.0 availability checks, however they do not work for macOS catalyst.
Which is why I added these checks:
```
#if !targetEnvironment(macCatalyst)
```
in front of ``#if swift(>=5.7)`` and ``@available(iOS 16, *)`` to be able to compile react-native apps for macOS catalyst