### PR TITLE
Docs: update outdated comments

### DIFF
--- a/src/types/AuxiliaryPreviewConfigDeprecated/MenuAuxiliaryPreviewConfig.ts
+++ b/src/types/AuxiliaryPreviewConfigDeprecated/MenuAuxiliaryPreviewConfig.ts
@@ -9,7 +9,7 @@ export type MenuAuxiliaryPreviewConfig = {
 
   anchorPosition?: MenuAuxiliaryPreviewAnchorPosition;
   alignmentHorizontal?: MenuAuxiliaryPreviewHorizontalAlignment;
-  
+
   marginPreview?: number;
   marginAuxiliaryPreview?: number;
 
@@ -17,13 +17,13 @@ export type MenuAuxiliaryPreviewConfig = {
 
   /**
    * The number of seconds to wait before showing the context menu
-   * 
+   *
    * The default is `AFTER_PREVIEW` (i.e. show the aux. preview after
    * the context menu becomes visible).
-   * 
+   *
    * Note: If you want to show the aux. preview as soon as possible,
-   * set this to `RECOMMENDED` (i.e. 0.25 seconds). A value of less 
-   * than 0.25 seconds may cause bugs.
+   * set this to `RECOMMENDED` (i.e. 0.325 seconds). A value of less
+   * than 0.325 seconds may cause bugs.
    */
   transitionEntranceDelay?: MenuAuxiliaryPreviewTransitionEntranceDelay;
 };


### PR DESCRIPTION
Hey, @dominicstop  I noticed that the default value for transitionEntranceDelay is 0.325s, so that comment is outdated. This PR just corrects it with code.  

![CleanShot 2024-02-08 at 06 22 20@2x](https://github.com/dominicstop/react-native-ios-context-menu/assets/37520667/711d5c1c-1c9b-4cb4-adf9-a27949c8b7bf)
