### PR TITLE
fix: codegen not resolving package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+	  "./package.json": "./package.json"
   },
   "files": [
     "src",


### PR DESCRIPTION
When trying to pod install, codegen fails with the following error:
```ts
error Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in node_modules/react-native-ios-context-menu/package.json
```

By adding `package.json` to the exports field the issue is resolved.
