### PR TITLE
Bump react-native-ios-utilities to be able to update to v4.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "expo": "*",
     "react": "*",
     "react-native": "*",
-    "react-native-ios-utilities": "4.4.x"
+    "react-native-ios-utilities": ">= 4.4.x <=4.5.x"
   },
   "release-it": {
     "git": {


### PR DESCRIPTION
Hello @dominicstop, this is my first open source contribution, so excuse me if i messed up with branches, tags. 

In this PR i suggest bump of react-native-ios-utilities and i explain why. In our project we are using
```
"expo": "~51.0.36",
"zeego": "^2.0.1",
"react-native-ios-context-menu": "^2.5.1",
"react-native-ios-utilities": "^4.4.5"
```


We were receiving a lot "App is hanging for at least 2000ms" from Sentry and we tried to investigate the cause (In reality hang duration was 10s). We found that the cause was "react-native-ios-utilities" because when we upgraded to ^4.5.1 hang stopped. At least by using Xcode Instruments we were able to replicate the hang and the fix. "react-native-ios-utilities" at v4.5.1 added support for expo [51](https://github.com/dominicstop/react-native-ios-utilities/commit/5d1d2c58f70a48701038af294de99884e8602445). Maybe this is the reason of the fix.

<img width="714" alt="Screenshot 2024-11-08 at 21 15 40" src="https://github.com/user-attachments/assets/417e7795-5bb2-4ae2-8851-10d1c7030029">

All suggestions are welcome :)