### PR TITLE
[2.X] Remove example-expo from npm package to improve npm install time

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ __tests__
 /android/build/
 /example/
 /assets
+/example-expo/


### PR DESCRIPTION
Hey @dominicstop,
the npm package version 2.5.2 includes the whole `example-expo/` folder in the published package (2.5.1 did not).
This caused the package to grow a lot:
tarball: 0.164Mb -> 193Mb
unpacked: 1.8Mb -> 745Mb

Would be really nice to remove those folder to speed up npm installs.

