### PR TITLE
feat: export jestSetup for mocks

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -1,0 +1,8 @@
+jest.mock("react-native-ios-context-menu", () => {
+  const RN = jest.requireActual("react-native");
+
+  return {
+    RCTContextMenuView: () => RN.View,
+    ContextMenuButton: "TouchableOpacity",
+  };
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
-    "!**/.*"
+    "!**/.*",
+    "jestSetup.js"
   ],
   "scripts": {
     "example": "yarn workspace react-native-ios-context-menu-example",


### PR DESCRIPTION
Hey folks,

I needed to set up a Jest mock for the library and found https://github.com/dominicstop/react-native-ios-context-menu/issues/12. I think the sample mock in that issue works pretty well, and including it in the codebase should make it easy to keep up to date.

I followed the naming scheme that [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler) uses (`jestSetup.js`) and added it to the `package.json` `files` array.

I'm happy to add some docs, but not exactly sure where the best spot to put them is. Users should be able to access the mock by importing it like this:

```ts
import "react-native-gesture-handler/jestSetup"
```

At the top of their `jest.setup.ts` file.