### PR TITLE
fix: framework support

### DIFF
--- a/.github/workflows/build-example-ios.yml
+++ b/.github/workflows/build-example-ios.yml
@@ -75,17 +75,38 @@ jobs:
       - name: Build JS
         run: yarn run bob build
 
-      - name: 1/2 - Run `pod-install` (fabric, static library)
+      - name: 1/4 - Run `pod-install` (fabric, static library)
         run: yarn pod-install:new-static
 
-      - name: 1/2 - Build example (fabric, static library)
+      - name: 1/4 - Build example (fabric, static library)
         run: yarn run build:ios
 
       - name: Clear/reset example pods
         run: yarn run nuke:example-pods
 
-      - name: 2/2 - Run `pod-install` (paper, static library)
+      - name: 2/4 - Run `pod-install` (paper, static library)
         run: yarn pod-install:old-static
 
-      - name: 2/2 - Build example (paper, static library)
+      - name: 2/4 - Build example (paper, static library)
         run: yarn run build:ios
+
+      - name: Clear/reset example pods
+        run: yarn run nuke:example-pods
+
+      - name: 3/4 - Run `pod-install` (fabric, dynamic library)
+        run: yarn pod-install:new-dynamic
+
+      - name: 3/4 - Build example (fabric, dynamic library)
+        run: yarn run build:ios
+
+      - name: Clear/reset example pods
+        run: yarn run nuke:example-pods
+
+      - name: 4/4 - Run `pod-install` (paper, dynamic library)
+        run: yarn pod-install:old-dynamic
+
+      - name: 4/4 - Build example (paper, dynamic library)
+        run: yarn run build:ios
+
+      - name: Clear/reset example pods
+        run: yarn run nuke:example-pods

--- a/ios/RNIContextMenuButton/RNIContextMenuButton.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButton.h
@@ -5,7 +5,11 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#else
 #import <react-native-ios-utilities/RNIBaseView.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButton.mm
+++ b/ios/RNIContextMenuButton/RNIContextMenuButton.mm
@@ -7,18 +7,33 @@
 
 #import "RNIContextMenuButton.h"
 
+#if __has_include(<react_native_ios_context_menu/Swift.h>)
+#import "react_native_ios_context_menu/Swift.h"
+
+#import <react_native_ios_utilities/RNIBaseView.h>
+#import <react_native_ios_utilities//RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+
+#else
 #import "react-native-ios-context-menu/Swift.h"
 
 #import <react-native-ios-utilities/RNIBaseView.h>
 #import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
 #import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
 #import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIContextMenuButtonComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState)
+#include <react_native_ios_utilities/RNIBaseViewState.h>
+#include <react_native_ios_utilities/RNIBaseViewProps.h>
+#else
 #include <react-native-ios-utilities/RNIBaseViewState.h>
 #include <react-native-ios-utilities/RNIBaseViewProps.h>
+#endif
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonViewManager.mm
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonViewManager.mm
@@ -8,7 +8,12 @@
 #import "RNIContextMenuButton.h"
 #import <objc/runtime.h>
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
+#import <react_native_ios_utilities/RNIBaseViewUtils.h>
+
+#else
 #import <react-native-ios-utilities/RNIBaseViewUtils.h>
+#endif
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/RNIContextMenuView/RNIContextMenuView.h
+++ b/ios/RNIContextMenuView/RNIContextMenuView.h
@@ -5,7 +5,11 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#else
 #import <react-native-ios-utilities/RNIBaseView.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/RNIContextMenuView/RNIContextMenuView.mm
+++ b/ios/RNIContextMenuView/RNIContextMenuView.mm
@@ -7,18 +7,33 @@
 
 #import "RNIContextMenuView.h"
 
+#if __has_include(<react_native_ios_context_menu/Swift.h>)
+#import "react_native_ios_context_menu/Swift.h"
+
+#import <react_native_ios_utilities/RNIBaseView.h>
+#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
 #import "react-native-ios-context-menu/Swift.h"
 
 #import <react-native-ios-utilities/RNIBaseView.h>
 #import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
 #import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
 #import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIContextMenuViewComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#include <react_native_ios_utilities/RNIBaseViewState.h>
+#include <react_native_ios_utilities/RNIBaseViewProps.h>
+
+#else
 #include <react-native-ios-utilities/RNIBaseViewState.h>
 #include <react-native-ios-utilities/RNIBaseViewProps.h>
+#endif
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/RNIContextMenuView/RNIContextMenuViewManager.mm
+++ b/ios/RNIContextMenuView/RNIContextMenuViewManager.mm
@@ -8,7 +8,12 @@
 #import "RNIContextMenuView.h"
 #import <objc/runtime.h>
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
+#import <react_native_ios_utilities/RNIBaseViewUtils.h>
+
+#else
 #import <react-native-ios-utilities/RNIBaseViewUtils.h>
+#endif
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/Swift.h
+++ b/ios/Swift.h
@@ -9,7 +9,7 @@
 // the module.
 // Otherwise, it's available only locally with double-quoted imports.
 #if __has_include(<react_native_ios_context_menu/react_native_ios_context_menu-Swift.h>)
-#import "<react_native_ios_context_menu/react_native_ios_context_menu-Swift.h>"
+#import <react_native_ios_context_menu/react_native_ios_context_menu-Swift.h>
 #else
 #import "react_native_ios_context_menu-Swift.h"
 #endif


### PR DESCRIPTION
Reopening https://github.com/dominicstop/react-native-ios-context-menu/pull/117, which got kind of messed up in some rebasing.

This will:

1. [x] Add more checks for different pod install configurations [like we did in `react-native-ios-utilities`](https://github.com/coolsoftwaretyler/react-native-ios-context-menu/commit/2c8a1bdff3a11ba45264ac0b0162efc51ee88da6)
2. [x] Fix import paths
