### PR TITLE
fix: dynamic library builds for Reanimated

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,6 +28,16 @@ target 'IosContextMenuExample' do
     # Pods for testing
   end
 
+  pre_install do |installer|
+    installer.pod_targets.each do |pod|
+      if pod.name.eql?('RNReanimated')
+        def pod.build_type
+          Pod::BuildType.static_library
+        end
+      end
+     end
+   end
+
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
     react_native_post_install(


### PR DESCRIPTION
I think this will fix the build error reported in [this comment](https://github.com/dominicstop/react-native-ios-context-menu/pull/118#issuecomment-2522028745), based on the fix in https://github.com/software-mansion/react-native-reanimated/issues/6062

To reproduce:

1. Pull down
2. Clean dependencies (I ran `yarn nuke:all`
3. `yarn install`
4. `cd example/ios`
5. `pod cache clean --all && USE_FRAMEWORKS="dynamic" pod install`
6. Build should work