### PR TITLE
fix: more header path issues

### DIFF
--- a/ios/RNIContextMenuButton/RNIContextMenuButton.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButton.h
@@ -5,11 +5,9 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
-#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
-#import <react_native_ios_utilities/RNIBaseView.h>
-#else
-#import <react-native-ios-utilities/RNIBaseView.h>
-#endif
+#import "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseView.h)
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButton.mm
+++ b/ios/RNIContextMenuButton/RNIContextMenuButton.mm
@@ -7,29 +7,16 @@
 
 #import "RNIContextMenuButton.h"
 #import "../Swift.h"
+#import "../RNIHeaderUtils.h"
 
-#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
-#import <react_native_ios_utilities/RNIBaseView.h>
-#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
-#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
-#import <react_native_ios_utilities/RNIObjcUtils.h>
-#else
-#import <react-native-ios-utilities/RNIBaseView.h>
-#import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
-#import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
-#import <react-native-ios-utilities/RNIObjcUtils.h>
-#endif
+#import RNI_INCLUDE_HEADER(RNIContentViewParentDelegate.h)
+#import RNI_INCLUDE_HEADER(UIApplication+RNIHelpers.h)
+#import RNI_INCLUDE_HEADER(RNIObjcUtils.h)
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIContextMenuButtonComponentDescriptor.h"
-
-#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
-#include <react_native_ios_utilities/RNIBaseViewState.h>
-#include <react_native_ios_utilities/RNIBaseViewProps.h>
-#else
-#include <react-native-ios-utilities/RNIBaseViewState.h>
-#include <react-native-ios-utilities/RNIBaseViewProps.h>
-#endif
+#import RNI_INCLUDE_HEADER(RNIBaseViewState.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewProps.h)
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButton.mm
+++ b/ios/RNIContextMenuButton/RNIContextMenuButton.mm
@@ -23,8 +23,13 @@
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIContextMenuButtonComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
 #include <react_native_ios_utilities/RNIBaseViewState.h>
 #include <react_native_ios_utilities/RNIBaseViewProps.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#include <react-native-ios-utilities/RNIBaseViewProps.h>
+#endif
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonComponentDescriptor.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonComponentDescriptor.h
@@ -10,12 +10,9 @@
 
 #include "RNIContextMenuButtonShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
+#include "../RNIHeaderUtils.h"
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
-#include <react_native_ios_utilities/RNIBaseViewState.h>
-#else
-#include <react-native-ios-utilities/RNIBaseViewState.h>
-#endif
+#import RNI_INCLUDE_HEADER(RNIBaseViewState.h)
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonComponentDescriptor.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonComponentDescriptor.h
@@ -11,7 +11,11 @@
 #include "RNIContextMenuButtonShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
 #include <react_native_ios_utilities/RNIBaseViewState.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#endif
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonShadowNode.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonShadowNode.h
@@ -8,15 +8,11 @@
 #if __cplusplus
 #pragma once
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
-#include <react_native_ios_utilities/RNIBaseViewShadowNode.h>
-#include <react_native_ios_utilities/RNIBaseViewProps.h>
-#include <react_native_ios_utilities/RNIBaseViewEventEmitter.h>
-#else
-#include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
-#include <react-native-ios-utilities/RNIBaseViewProps.h>
-#include <react-native-ios-utilities/RNIBaseViewEventEmitter.h>
-#endif
+#include "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseViewShadowNode.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewProps.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewEventEmitter.h)
 
 #include <react/renderer/components/RNIContextMenuViewSpec/EventEmitters.h>
 #include <react/renderer/components/RNIContextMenuViewSpec/Props.h>
@@ -34,7 +30,7 @@ class JSI_EXPORT RNIContextMenuButtonShadowNode final :
 
 public:
   using RNIBaseViewShadowNode::RNIBaseViewShadowNode;
-  
+
   static RNIBaseViewState initialStateData(
       const Props::Shared&r          , // props
       const ShadowNodeFamily::Shared&, // family

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonShadowNode.h
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonShadowNode.h
@@ -8,9 +8,15 @@
 #if __cplusplus
 #pragma once
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
 #include <react_native_ios_utilities/RNIBaseViewShadowNode.h>
 #include <react_native_ios_utilities/RNIBaseViewProps.h>
 #include <react_native_ios_utilities/RNIBaseViewEventEmitter.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
+#include <react-native-ios-utilities/RNIBaseViewProps.h>
+#include <react-native-ios-utilities/RNIBaseViewEventEmitter.h>
+#endif
 
 #include <react/renderer/components/RNIContextMenuViewSpec/EventEmitters.h>
 #include <react/renderer/components/RNIContextMenuViewSpec/Props.h>

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonViewManager.mm
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonViewManager.mm
@@ -8,11 +8,9 @@
 #import "RNIContextMenuButton.h"
 #import <objc/runtime.h>
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
-#import <react_native_ios_utilities/RNIBaseViewUtils.h>
-#else
-#import <react-native-ios-utilities/RNIBaseViewUtils.h>
-#endif
+#import "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseViewUtils.h)
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/RNIContextMenuView/RNIContextMenuView.h
+++ b/ios/RNIContextMenuView/RNIContextMenuView.h
@@ -5,11 +5,9 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
-#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
-#import <react_native_ios_utilities/RNIBaseView.h>
-#else
-#import <react-native-ios-utilities/RNIBaseView.h>
-#endif
+#import "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseView.h)
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/RNIContextMenuView/RNIContextMenuView.mm
+++ b/ios/RNIContextMenuView/RNIContextMenuView.mm
@@ -8,28 +8,22 @@
 #import "RNIContextMenuView.h"
 #import "../Swift.h"
 
-#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
-#import <react_native_ios_utilities/RNIBaseView.h>
-#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
-#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
-#import <react_native_ios_utilities/RNIObjcUtils.h>
-#else
-#import <react-native-ios-utilities/RNIBaseView.h>
-#import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
-#import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
-#import <react-native-ios-utilities/RNIObjcUtils.h>
+#import "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseView.h)
+#import RNI_INCLUDE_HEADER(RNIContentViewParentDelegate.h)
+#import RNI_INCLUDE_HEADER(UIApplication+RNIHelpers.h)
+#import RNI_INCLUDE_HEADER(RNIObjcUtils.h)
+
+#if RCT_NEW_ARCH_ENABLED
+#import RNI_INCLUDE_HEADER(RNIBaseViewState.h)
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIContextMenuViewComponentDescriptor.h"
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
-#include <react_native_ios_utilities/RNIBaseViewState.h>
-#include <react_native_ios_utilities/RNIBaseViewProps.h>
-#else
-#include <react-native-ios-utilities/RNIBaseViewState.h>
-#include <react-native-ios-utilities/RNIBaseViewProps.h>
-#endif
+#import RNI_INCLUDE_HEADER(RNIBaseViewState.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewProps.h)
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/RNIContextMenuView/RNIContextMenuViewComponentDescriptor.h
+++ b/ios/RNIContextMenuView/RNIContextMenuViewComponentDescriptor.h
@@ -29,7 +29,7 @@ class RNIContextMenuViewComponentDescriptor final : public RNIBaseViewComponentD
   RNIContextMenuViewShadowNode,
   RNIContextMenuViewComponentName
 > {
-  
+
 public:
   using RNIBaseViewComponentDescriptor::RNIBaseViewComponentDescriptor;
 };

--- a/ios/RNIContextMenuView/RNIContextMenuViewComponentDescriptor.h
+++ b/ios/RNIContextMenuView/RNIContextMenuViewComponentDescriptor.h
@@ -8,11 +8,17 @@
 #if __cplusplus
 #pragma once
 
+
 #include "RNIContextMenuViewShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewComponentDescriptor.h>)
 #include <react_native_ios_utilities/RNIBaseViewComponentDescriptor.h>
 #include <react_native_ios_utilities/RNIBaseViewState.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewComponentDescriptor.h>
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#endif
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/ios/RNIContextMenuView/RNIContextMenuViewManager.mm
+++ b/ios/RNIContextMenuView/RNIContextMenuViewManager.mm
@@ -8,11 +8,9 @@
 #import "RNIContextMenuView.h"
 #import <objc/runtime.h>
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
-#import <react_native_ios_utilities/RNIBaseViewUtils.h>
-#else
-#import <react-native-ios-utilities/RNIBaseViewUtils.h>
-#endif
+#import "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseViewUtils.h)
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/RNIContextMenuView/RNIContextMenuViewShadowNode.h
+++ b/ios/RNIContextMenuView/RNIContextMenuViewShadowNode.h
@@ -8,15 +8,11 @@
 #if __cplusplus
 #pragma once
 
-#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
-#include <react_native_ios_utilities/RNIBaseViewShadowNode.h>
-#include <react_native_ios_utilities/RNIBaseViewProps.h>
-#include <react_native_ios_utilities/RNIBaseViewEventEmitter.h>
-#else
-#include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
-#include <react-native-ios-utilities/RNIBaseViewProps.h>
-#include <react-native-ios-utilities/RNIBaseViewEventEmitter.h>
-#endif
+#include "../RNIHeaderUtils.h"
+
+#import RNI_INCLUDE_HEADER(RNIBaseViewShadowNode.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewProps.h)
+#import RNI_INCLUDE_HEADER(RNIBaseViewEventEmitter.h)
 
 #include <react/renderer/components/RNIContextMenuViewSpec/EventEmitters.h>
 #include <react/renderer/components/RNIContextMenuViewSpec/Props.h>
@@ -34,7 +30,7 @@ class JSI_EXPORT RNIContextMenuViewShadowNode final :
 
 public:
   using RNIBaseViewShadowNode::RNIBaseViewShadowNode;
-  
+
   static RNIBaseViewState initialStateData(
       const Props::Shared&r          , // props
       const ShadowNodeFamily::Shared&, // family

--- a/ios/RNIContextMenuView/RNIContextMenuViewShadowNode.h
+++ b/ios/RNIContextMenuView/RNIContextMenuViewShadowNode.h
@@ -8,9 +8,15 @@
 #if __cplusplus
 #pragma once
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
 #include <react_native_ios_utilities/RNIBaseViewShadowNode.h>
 #include <react_native_ios_utilities/RNIBaseViewProps.h>
 #include <react_native_ios_utilities/RNIBaseViewEventEmitter.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
+#include <react-native-ios-utilities/RNIBaseViewProps.h>
+#include <react-native-ios-utilities/RNIBaseViewEventEmitter.h>
+#endif
 
 #include <react/renderer/components/RNIContextMenuViewSpec/EventEmitters.h>
 #include <react/renderer/components/RNIContextMenuViewSpec/Props.h>

--- a/ios/RNIHeaderUtils.h
+++ b/ios/RNIHeaderUtils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if __has_include(<react_native_ios_utilities/header>)
+    #define RNI_INCLUDE_HEADER(header) <react_native_ios_utilities/header>
+#else
+    #define RNI_INCLUDE_HEADER(header) <react-native-ios-utilities/header>
+#endif

--- a/ios/Swift.h
+++ b/ios/Swift.h
@@ -4,10 +4,6 @@
 //
 //  Created by Dominic Go on 8/24/24.
 //
-
-// When `use_frameworks!` is used, the generated Swift header is inside
-// the module.
-// Otherwise, it's available only locally with double-quoted imports.
 #if __has_include(<react_native_ios_context_menu/react_native_ios_context_menu-Swift.h>)
 #import <react_native_ios_context_menu/react_native_ios_context_menu-Swift.h>
 

--- a/react-native-ios-context-menu.podspec
+++ b/react-native-ios-context-menu.podspec
@@ -68,7 +68,7 @@ Pod::Spec.new do |s|
     '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-ios-utilities/**"',
     '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-ios-utilities/Swift Compatibility Header"',
     '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-ios-context-menu/Swift Compatibility Header"',
-    
+
     #'"$(PODS_ROOT)/Headers/Private/react-native-ios-utilities"',
     #'"$(PODS_ROOT)/Headers/Public/react-native-ios-utilities"',
 
@@ -76,7 +76,7 @@ Pod::Spec.new do |s|
     '"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers"',
     '"$(PODS_ROOT)/Headers/Private/Yoga"',
   ]
-  
+
   if fabric_enabled && ENV['USE_FRAMEWORKS']
     user_header_search_paths << "\"$(PODS_ROOT)/DoubleConversion\""
     user_header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\""
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => user_header_search_paths,
   }
 
-  # s.xcconfig = { 
+  # s.xcconfig = {
   #   'HEADER_SEARCH_PATHS' => [
   #     '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-ios-utilities/Swift Compatibility Header"',
   #     '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-ios-utilities/**"',
@@ -138,5 +138,5 @@ Pod::Spec.new do |s|
 
   s.exclude_files = exclude_files
   s.compiler_flags = compiler_flags
-  s.private_header_files = ['ios/**/*+Private.h', 'ios/**/Swift.h']
+  s.private_header_files = ['ios/**/*+Private.h', 'ios/**/Swift.h', 'ios/**/RNIHeaderUtils.h']
 end


### PR DESCRIPTION
This PR closes https://github.com/dominicstop/react-native-ios-context-menu/issues/120 by updating the header paths to support both hyphens and underscores.

The first commit, [828bc0f](https://github.com/dominicstop/react-native-ios-context-menu/pull/121/commits/828bc0f32b5c8515eec6b2ae2283b6380150f24f), fixes it the way we've been writing them up until now.

In [cd7840e](https://github.com/dominicstop/react-native-ios-context-menu/pull/121/commits/cd7840ecd476c90f13e6a6ccb97ee2bc058b717a), I wrote a macro to clean up those imports. Since we can't encapsulate `#if` statements in the preprocessor, it's not as clean as I'd like, but it does reduce all of the conditionals in each file.

You can see the first patch working in my reproducer repo, at this commit: https://github.com/coolsoftwaretyler/react-native-ios-utilities-missing-header-expo-52-reproducer/commit/bfe92e1709e7ecbcd344289835e3927acc1fa520

You can see the second patch working in the reproducer at: https://github.com/coolsoftwaretyler/react-native-ios-utilities-missing-header-expo-52-reproducer/commit/8dd31330a8bb800d4f6b07b83b0a77cabc23c3db

To verify:

1. Pull down the reproducer
2. `rm -rf node_modules/ android/ ios/` for a clean start
3. `npm install`
4. `npm run patch`
5. `npx expo prebuild`
6. `npm run ios`

Build should work.
