### PR TITLE
Fix accessibility issues in Dropdown Menus

### DIFF
--- a/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
@@ -138,6 +138,7 @@ public final class RNIContextMenuButtonContent: UIButton, RNIContentView {
     self._didSetup = true;
     
     self.isEnabled = true;
+    self.isAccessibilityElement = false;
   };
     
   // MARK: Functions


### PR DESCRIPTION
To VoiceOver, the dropdown menu trigger button is just read out as 'button'.

This is because by default, a UIButton has isAccessibilityElement=true. This means that everything inside of it is invisible to the screen reader.

In order to improve accessibility, it's necessary to set isAccessibilityElement to false so that the screen reader can access the react native component that the user has provided to be the trigger button for the context menu.


Here are some videos showing the VoiceOver experience before & after my change:

Before:
https://github.com/user-attachments/assets/01930ffb-1834-45cd-b65e-38f16cc5dc9f

After:
https://github.com/user-attachments/assets/68d8a0a1-2ed2-4f97-ba8f-b3e44f79ac17



## QA Notes
I was unable to build the example app in this project, so I used the Zeego example app which depends on this project to test this change.