### PR TITLE
fix: fix ios codegen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,13 @@
   "codegenConfig": {
     "name": "RNIContextMenuViewSpec",
     "type": "all",
-    "jsSrcsDir": "src"
+    "jsSrcsDir": "src",
+    "ios": {
+      "componentProvider": {
+        "RNIContextMenuView": "RNIContextMenuView",
+        "RNIContextMenuButton": "RNIContextMenuButton"
+      }
+    }
   },
   "create-react-native-library": {
     "type": "view-new",


### PR DESCRIPTION
The app crashed on 0.80.1 because of an incomplete codegen config. This fixes it.