### PR TITLE
fix: emit typescript declarations in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A react-native component to use context menu's (UIMenu) on iOS 13/14+",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/module/src/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+    "noEmit": false
+  },
   "exclude": ["example", "lib", "example-expo"]
 }


### PR DESCRIPTION
This fixes #129 and adds back the missing type declarations.