### PR TITLE
fix: guard against view not in window when creating UITargetedPreview

### DIFF
--- a/ios/RNIContextMenuView/RNIContextMenuViewContent+UIContextMenuInteractionDelegate.swift
+++ b/ios/RNIContextMenuView/RNIContextMenuViewContent+UIContextMenuInteractionDelegate.swift
@@ -201,7 +201,7 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
     configuration: UIContextMenuConfiguration,
     highlightPreviewForItemWithIdentifier identifier: NSCopying
   ) -> UITargetedPreview? {
-    
+    guard self.menuPreviewTargetView.window != nil else { return nil };
     return self.menuTargetedPreview;
   };
   #else
@@ -210,19 +210,19 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
     _ : UIContextMenuInteraction,
     previewForHighlightingMenuWithConfiguration: UIContextMenuConfiguration
   ) -> UITargetedPreview? {
-  
+    guard self.menuPreviewTargetView.window != nil else { return nil };
     return self.menuTargetedPreview;
   };
   #endif
-  
-  
+
+
   #if swift(>=5.7)
   public func contextMenuInteraction(
       _ interaction: UIContextMenuInteraction,
       configuration: UIContextMenuConfiguration,
       dismissalPreviewForItemWithIdentifier identifier: NSCopying
   ) -> UITargetedPreview? {
-    
+    guard self.menuPreviewTargetView.window != nil else { return nil };
     return self.menuTargetedPreview;
   };
   #else
@@ -232,7 +232,7 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
     previewForDismissingMenuWithConfiguration
     configuration: UIContextMenuConfiguration
   ) -> UITargetedPreview? {
-    
+    guard self.menuPreviewTargetView.window != nil else { return nil };
     return self.menuTargetedPreview;
   };
   #endif


### PR DESCRIPTION
## Summary

When a context menu's source view is removed from the window hierarchy while the menu is still visible (e.g. due to a list rerender, navigation event, or real-time data update), UIKit crashes with:

```
NSInternalInconsistencyException
BUG_IN_CLIENT_OF_TARGETED_PREVIEW__VIEW_IS_NOT_IN_A_WINDOW
```

This happens because `UITargetedPreview(view:parameters:)` is called with a view that has no `window`, which UIKit does not allow.

## Fix

Adds a `menuPreviewTargetView.window != nil` guard to all four `UITargetedPreview` delegate methods (highlight + dismissal, both iOS 16+ and deprecated variants). Returning `nil` tells UIKit to use a default fade animation instead of crashing.

## Crash stack trace

```
Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 __exceptionPreprocess
1  libobjc.A.dylib                objc_exception_throw
2  Foundation                     -[NSMutableDictionary initWithContentsOfFile:]
3  UIKitCore                      BUG_IN_CLIENT_OF_TARGETED_PREVIEW__VIEW_IS_NOT_IN_A_WINDOW
4  UIKitCore                      -[UITargetedPreview initWithView:parameters:]
5  ChatXOS                        RNIContextMenuViewContent.menuTargetedPreview.getter
6  ChatXOS                        RNIContextMenuViewContent.contextMenuInteraction(_:configuration:dismissalPreviewForItemWithIdentifier:)
```