### PR TITLE
fix: tapping outside menu

### DIFF
--- a/ios/RNIContextMenuButton/RNIContextMenuButtonContent+UIContextMenuInteractionDelegate.swift
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonContent+UIContextMenuInteractionDelegate.swift
@@ -12,22 +12,59 @@ import react_native_ios_utilities
 
 @available(iOS 13, *)
 extension RNIContextMenuButtonContent {
-  
+
+  /// Walks up the view hierarchy to find the React touch handler gesture
+  /// recognizer. Supports both old arch (`RCTTouchHandler`) and new arch
+  /// / Fabric (`RCTSurfaceTouchHandler`) by matching the class name.
+  private func findReactTouchHandler() -> UIGestureRecognizer? {
+    // Try the old-arch helper first
+    if let parentReactView = self.parentReactView as? RCTView,
+       let handler = parentReactView.closestParentReactTouchHandler
+    {
+      return handler;
+    };
+
+    // Fallback: walk the view hierarchy and match by class name
+    var currentView: UIView? = self;
+    while let view = currentView {
+      if let match = view.gestureRecognizers?.first(where: {
+        let className = NSStringFromClass(type(of: $0));
+        return className.contains("TouchHandler");
+      }) {
+        return match;
+      };
+      currentView = view.superview;
+    };
+
+    return nil;
+  };
+
   // context menu display begins
   public override func contextMenuInteraction(
     _ interaction: UIContextMenuInteraction,
     willDisplayMenuFor configuration: UIContextMenuConfiguration,
     animator: UIContextMenuInteractionAnimating?
   ) {
-    
+
     self.isContextMenuVisible = true;
+
+    // Disable the React touch handler for the entire lifetime of the
+    // context menu. This prevents the dismiss tap from leaking through
+    // to views behind the menu (e.g. selecting a row in a list).
+    // The touch handler is re-enabled in `willEndFor`'s animator
+    // completion, after the dismiss animation finishes.
+    if let touchHandler = self.findReactTouchHandler() {
+      touchHandler.isEnabled = false;
+      self._disabledTouchHandler = touchHandler;
+    };
+
     guard let animator = animator else { return };
-        
+
     self.dispatchEvent(
       for: .onMenuWillShow,
       withPayload: [:]
     );
-    
+
     animator.addCompletion { [unowned self] in
       self.dispatchEvent(
         for: .onMenuDidShow,
@@ -35,22 +72,22 @@ extension RNIContextMenuButtonContent {
       );
     };
   };
-  
+
   // context menu display ends
   public override func contextMenuInteraction(
     _ interaction: UIContextMenuInteraction,
     willEndFor configuration: UIContextMenuConfiguration,
     animator: UIContextMenuInteractionAnimating?
   ) {
-    
+
     defer {
       // reset flag
       self.isContextMenuVisible = false;
       self.isUserInteractionEnabled = true;
     };
-    
+
     guard self.isContextMenuVisible else { return };
-    
+
     self.dispatchEvent(
       for: .onMenuWillHide,
       withPayload: [:]
@@ -63,13 +100,18 @@ extension RNIContextMenuButtonContent {
         withPayload: [:]
       );
     };
-    
+
     animator?.addCompletion { [unowned self] in
+      // Re-enable the React touch handler that was disabled in
+      // `willDisplayMenuFor`
+      self._disabledTouchHandler?.isEnabled = true;
+      self._disabledTouchHandler = nil;
+
       self.dispatchEvent(
         for: .onMenuDidHide,
         withPayload: [:]
       );
-      
+
       if !self.didPressMenuItem {
         // nothing was selected...
         self.dispatchEvent(
@@ -77,7 +119,7 @@ extension RNIContextMenuButtonContent {
           withPayload: [:]
         );
       };
-      
+
       // reset flag
       self.didPressMenuItem = false;
     };

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
@@ -43,12 +43,16 @@ public final class RNIContextMenuButtonContent: UIButton, RNIContentView {
   // ----------------
   
   var _didSetup = false;
-  
+
   var _deferredElementCompletionMap:
     [String: RNIDeferredMenuElement.CompletionHandler] = [:];
-    
+
   weak var navEventsVC: RNINavigationEventsReportingViewController?;
   var longPressGestureRecognizer: UILongPressGestureRecognizer!;
+
+  /// Reference to the React touch handler that was disabled while the
+  /// context menu is visible, so it can be re-enabled on dismiss.
+  weak var _disabledTouchHandler: UIGestureRecognizer?;
     
   // MARK: Public Properties
   // -----------------------

--- a/ios/RNIContextMenuView/RNIContextMenuViewContent+UIContextMenuInteractionDelegate.swift
+++ b/ios/RNIContextMenuView/RNIContextMenuViewContent+UIContextMenuInteractionDelegate.swift
@@ -52,15 +52,22 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
     
     self.isContextMenuVisible = true;
     guard let animator = animator else { return };
-    
+
     if self.shouldPreventLongPressGestureFromPropagating,
        let parentReactView = self.parentReactView as? RCTView
     {
       self.isUserInteractionEnabled = false;
       self.menuAuxiliaryPreviewParent?.isUserInteractionEnabled = false;
-      
-      parentReactView.closestParentReactTouchHandler?.cancel();
-      
+
+      // Cancel any in-flight gesture and disable the touch handler for
+      // the entire lifetime of the context menu. This prevents the
+      // dismiss tap from leaking through to views behind the menu.
+      // The touch handler is re-enabled in `willEndFor`'s animator
+      // completion, after the dismiss animation finishes.
+      let touchHandler = parentReactView.closestParentReactTouchHandler;
+      touchHandler?.cancel();
+      touchHandler?.isEnabled = false;
+
       DispatchQueue.main.async {
         self.isUserInteractionEnabled = true;
         self.menuAuxiliaryPreviewParent?.isUserInteractionEnabled = true;
@@ -98,24 +105,24 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
     defer {
       // reset flag
       self.isContextMenuVisible = false;
-      
+
       self.isUserInteractionEnabled = true;
       self.menuAuxiliaryPreviewParent?.isUserInteractionEnabled = true;
     };
-    
+
     guard self.isContextMenuVisible else { return };
-    
+
     self.dispatchEvent(
       for: .onMenuWillHide,
       withPayload: [:]
     );
-    
+
     self.contextMenuManager?.notifyOnContextMenuInteraction(
       interaction,
       willEndFor: configuration,
       animator: animator
     );
-    
+
     if !self.didPressMenuItem {
       // nothing was selected...
       self.dispatchEvent(
@@ -123,13 +130,22 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
         withPayload: [:]
       );
     };
-    
+
     animator?.addCompletion { [unowned self] in
+      // Re-enable the React touch handler that was disabled in
+      // `willDisplayMenuFor`. This must happen after the dismiss
+      // animation finishes so the dismiss tap cannot leak through.
+      if self.shouldPreventLongPressGestureFromPropagating,
+         let parentReactView = self.parentReactView as? RCTView
+      {
+        parentReactView.closestParentReactTouchHandler?.isEnabled = true;
+      };
+
       self.dispatchEvent(
         for: .onMenuDidHide,
         withPayload: [:]
       );
-      
+
       if !self.didPressMenuItem {
         // nothing was selected...
         self.dispatchEvent(
@@ -137,7 +153,7 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
           withPayload: [:]
         );
       };
-      
+
       // reset flag
       self.didPressMenuItem = false;
     };
@@ -151,9 +167,17 @@ extension RNIContextMenuViewContent: UIContextMenuInteractionDelegate {
   ) {
     
     let preferredCommitStyle = self.previewConfig.preferredCommitStyle;
-    
+
     self.isContextMenuVisible = false;
     animator.preferredCommitStyle = preferredCommitStyle;
+
+    // Re-enable the React touch handler that was disabled in
+    // `willDisplayMenuFor`
+    if self.shouldPreventLongPressGestureFromPropagating,
+       let parentReactView = self.parentReactView as? RCTView
+    {
+      parentReactView.closestParentReactTouchHandler?.isEnabled = true;
+    };
     
     switch preferredCommitStyle {
       case .pop:


### PR DESCRIPTION
# What

When tapping outside a context menu to dismiss, the touch event forwards to views behind it.

Fix: Disable React's touch handler gesture recognizer for the entire lifetime of the context menu, then re-enable it after the dismiss animation completes.