### PR TITLE
feat: previewConfig support for ContextMenuButton

### DIFF
--- a/ios/RNIContextMenuButton/RNIContextMenuButtonContent+UIContextMenuInteractionDelegate.swift
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonContent+UIContextMenuInteractionDelegate.swift
@@ -124,4 +124,77 @@ extension RNIContextMenuButtonContent {
       self.didPressMenuItem = false;
     };
   };
+
+  // context menu highlight preview - controls the shape of the
+  // open/close transition (e.g. preserves rounded corners during the morph).
+  //
+  // NOTE: never call super in these overrides - UIButton declares them
+  // (which is what makes `override` compile), but does not implement them,
+  // so calling super crashes with an unrecognized selector. Returning nil
+  // tells UIKit to create the default targeted preview instead.
+  #if swift(>=5.7)
+  @available(iOS 16.0, *)
+  public override func contextMenuInteraction(
+    _ interaction: UIContextMenuInteraction,
+    configuration: UIContextMenuConfiguration,
+    highlightPreviewForItemWithIdentifier identifier: NSCopying
+  ) -> UITargetedPreview? {
+
+    guard self.previewConfig.borderRadius != nil,
+          self.window != nil
+    else { return nil };
+
+    return self.menuTargetedPreview;
+  };
+  #else
+  /// deprecated in iOS 16
+  public override func contextMenuInteraction(
+    _ interaction: UIContextMenuInteraction,
+    previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration
+  ) -> UITargetedPreview? {
+
+    guard self.previewConfig.borderRadius != nil,
+          self.window != nil
+    else { return nil };
+
+    return self.menuTargetedPreview;
+  };
+  #endif
+
+  // NOTE: unlike the highlight method (where nil means "use the default
+  // preview"), returning nil here makes the menu fade out in place instead
+  // of morphing back into the button. Always return a preview targeting
+  // the button, unless it left the window.
+  #if swift(>=5.7)
+  @available(iOS 16.0, *)
+  public override func contextMenuInteraction(
+    _ interaction: UIContextMenuInteraction,
+    configuration: UIContextMenuConfiguration,
+    dismissalPreviewForItemWithIdentifier identifier: NSCopying
+  ) -> UITargetedPreview? {
+
+    guard self.window != nil else { return nil };
+
+    guard self.previewConfig.borderRadius != nil else {
+      return .init(view: self);
+    };
+
+    return self.menuTargetedPreview;
+  };
+  #else
+  /// deprecated in iOS 16
+  public override func contextMenuInteraction(
+    _ interaction: UIContextMenuInteraction,
+    previewForDismissingMenuWithConfiguration configuration: UIContextMenuConfiguration
+  ) -> UITargetedPreview? {
+
+    guard self.window != nil else { return nil };
+
+    guard self.previewConfig.borderRadius != nil else {
+      return .init(view: self);
+    };
+
+    return self.menuTargetedPreview;
+  };
+  #endif
 };

--- a/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
+++ b/ios/RNIContextMenuButton/RNIContextMenuButtonContent.swift
@@ -35,6 +35,7 @@ public final class RNIContextMenuButtonContent: UIButton, RNIContentView {
   
   public static var propKeyPathMap: Dictionary<String, PartialKeyPath<RNIContextMenuButtonContent>> = [
     "menuConfig": \.menuConfigProp,
+    "previewConfig": \.previewConfigProp,
     "isContextMenuEnabled": \.isContextMenuEnabled,
     "isMenuPrimaryAction": \.isMenuPrimaryAction,
   ];
@@ -109,6 +110,19 @@ public final class RNIContextMenuButtonContent: UIButton, RNIContentView {
     }
   };
   
+  private(set) public var previewConfig = RNIMenuPreviewConfig();
+  @objc public var previewConfigProp: NSDictionary? {
+    willSet {
+      guard let newValue = newValue as? Dictionary<String, Any> else {
+        return;
+      };
+
+      let previewConfig = try? RNIMenuPreviewConfig(fromDict: newValue);
+      self.previewConfig = previewConfig ?? .init();
+      self.applyPreviewBorderRadiusToLayerIfNeeded();
+    }
+  };
+
   @objc public var isContextMenuEnabled = true {
     willSet {
       guard #available(iOS 14.0, *) else { return };
@@ -123,6 +137,69 @@ public final class RNIContextMenuButtonContent: UIButton, RNIContentView {
     }
   };
   
+  // MARK: - Computed Properties
+  // ---------------------------
+
+  /// create `UIPreviewParameters` based on `previewConfig`
+  var menuPreviewParameters: UIPreviewParameters {
+    let param = UIPreviewParameters();
+
+    // set preview bg color
+    param.backgroundColor = self.previewConfig.backgroundColor;
+
+    // set the preview border shape
+    if let borderRadius = self.previewConfig.borderRadius {
+      // clamp so oversized radii (e.g. 9999 for "fully rounded") produce
+      // a valid capsule/circle path instead of a malformed bezier path
+      let borderRadiusClamped = min(
+        borderRadius,
+        min(self.bounds.width, self.bounds.height) / 2
+      );
+
+      let previewShape = UIBezierPath(
+        roundedRect: self.bounds,
+        cornerRadius: borderRadiusClamped
+      );
+
+      // set preview border shape
+      param.visiblePath = previewShape;
+
+      // set preview border shadow
+      if #available(iOS 14, *){
+        param.shadowPath = previewShape;
+      };
+    };
+
+    return param;
+  };
+
+  var menuTargetedPreview: UITargetedPreview {
+    .init(
+      view: self,
+      parameters: self.menuPreviewParameters
+    );
+  };
+
+  /// Keep the button's own layer shape in sync with the preview shape -
+  /// the first frame of the context menu transition is derived from the
+  /// layer's corner radius, before `UIPreviewParameters.visiblePath`
+  /// takes over. Without this the first frame flashes as a rounded rect.
+  func applyPreviewBorderRadiusToLayerIfNeeded(){
+    guard let borderRadius = self.previewConfig.borderRadius else { return };
+
+    let borderRadiusClamped = min(
+      borderRadius,
+      min(self.bounds.width, self.bounds.height) / 2
+    );
+
+    self.layer.cornerRadius = borderRadiusClamped;
+  };
+
+  public override func layoutSubviews() {
+    super.layoutSubviews();
+    self.applyPreviewBorderRadiusToLayerIfNeeded();
+  };
+
   // MARK: Init
   // ----------
   

--- a/ios/RNIContextMenuView/RNIContextMenuViewContent.swift
+++ b/ios/RNIContextMenuView/RNIContextMenuViewContent.swift
@@ -210,6 +210,13 @@ public final class RNIContextMenuViewContent: UIView, RNIContentView {
     
     // set the preview border shape
     if let borderRadius = self.previewConfig.borderRadius {
+      // clamp so oversized radii (e.g. 9999 for "fully rounded") produce
+      // a valid capsule/circle path instead of a degenerate (empty) path
+      let borderRadiusClamped = min(
+        borderRadius,
+        min(self.frame.width, self.frame.height) / 2
+      );
+
       let previewShape = UIBezierPath(
         // get width/height from custom preview view
         roundedRect: CGRect(
@@ -217,7 +224,7 @@ public final class RNIContextMenuViewContent: UIView, RNIContentView {
           size  : self.frame.size
         ),
         // set the preview corner radius
-        cornerRadius: borderRadius
+        cornerRadius: borderRadiusClamped
       );
       
       // set preview border shape

--- a/src/components/ContextMenuButton/ContextMenuButton.tsx
+++ b/src/components/ContextMenuButton/ContextMenuButton.tsx
@@ -30,6 +30,7 @@ export class ContextMenuButton extends React.PureComponent<ContextMenuButtonProp
   private getProps = () => {
     const {
       menuConfig,
+      previewConfig,
       isContextMenuEnabled,
       isMenuPrimaryAction,
       onMenuWillShow,
@@ -54,6 +55,7 @@ export class ContextMenuButton extends React.PureComponent<ContextMenuButtonProp
 
       // B. Pass down props...
       menuConfig,
+      previewConfig,
       onMenuWillShow,
       onMenuWillHide,
       onMenuWillCancel,
@@ -158,6 +160,7 @@ export class ContextMenuButton extends React.PureComponent<ContextMenuButtonProp
     // TODO: Rename to 'sharedProps'
     const nativeComponentProps = {
       menuConfig: props.menuConfig,
+      previewConfig: props.previewConfig,
       isContextMenuEnabled: props.isContextMenuEnabled,
       isMenuPrimaryAction: props.isMenuPrimaryAction,
 

--- a/src/components/ContextMenuButton/ContextMenuButtonTypes.tsx
+++ b/src/components/ContextMenuButton/ContextMenuButtonTypes.tsx
@@ -6,6 +6,7 @@ import type { ContextMenuViewProps } from '../ContextMenuView';
 export type ContextMenuButtonInheritedProps = Partial<Pick<RNIContextMenuButtonProps,
   | 'isMenuPrimaryAction'
   | 'menuConfig'
+  | 'previewConfig'
   | 'isContextMenuEnabled'
 
   // Lifecycle Events

--- a/src/native_components/RNIContextMenuButton/RNIContextMenuButtonNativeComponent.ts
+++ b/src/native_components/RNIContextMenuButton/RNIContextMenuButtonNativeComponent.ts
@@ -11,6 +11,7 @@ export interface NativeProps extends ViewProps {
 
   // inherited props
   menuConfig?: string;
+  previewConfig?: string;
   isContextMenuEnabled?: boolean;
 
   onMenuWillShow?: BubblingEventHandler<{}>;

--- a/src/native_components/RNIContextMenuButton/RNIContextMenuButtonNativeView.ts
+++ b/src/native_components/RNIContextMenuButton/RNIContextMenuButtonNativeView.ts
@@ -14,6 +14,7 @@ type RNIContextMenuButtonNativeComponentBaseProps =
 
 export type RNIContextMenuNativeViewInheritedProps = Pick<RNIContextMenuNativeViewBaseProps,
   | 'menuConfig'
+  | 'previewConfig'
   | 'isContextMenuEnabled'
   | 'onMenuWillShow'
   | 'onMenuDidShow'

--- a/src/native_components/RNIContextMenuButton/RNIContextMenuButtonTypes.ts
+++ b/src/native_components/RNIContextMenuButton/RNIContextMenuButtonTypes.ts
@@ -21,6 +21,7 @@ export type RNIContextMenuButtonRef = {
 export type RNIContextMenuButtonInheritedOptionalProps = Partial<Pick<RNIContextMenuButtonNativeViewProps,
   // Value Props
   | 'menuConfig'
+  | 'previewConfig'
 
   // Lifecycle Events
   | 'onDidSetViewID'


### PR DESCRIPTION
# What

`ContextMenuView` supports `previewConfig`, but `ContextMenuButton` doesn't, so there is no way to control the shape of the highlight preview for button menus. Rounded triggers snap to a sharp-cornered rectangle during the open/close transition, which is very visible with the glass morph on iOS 26.

This adds `previewConfig` support to `ContextMenuButton`:

- `borderRadius` shapes the highlight and dismissal previews, reusing the same `UIPreviewParameters` logic as `ContextMenuView`. The radius is clamped to half the view size, so a large value gives a circle/capsule.
- The button layer's `cornerRadius` is kept in sync with it, otherwise the first frame of the transition flashes with the default shape.
- The overrides never call super: `UIButton` declares these delegate methods (which is what makes `override` compile) but doesn't implement them, so calling super crashes with an unrecognized selector.
- The dismissal override always returns a targeted preview, because returning nil there makes the menu fade out in place instead of morphing back into the button. It only returns nil when the view left the window, same guard as #140.

Tested on a device running iOS 26. Needed for nandorojo/zeego#157.